### PR TITLE
ISSUE25 - fixed multiValue complex type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.8-dev"  # 3.8 development branch
   - "3.8"
   - "3.9-dev"  # 3.9 development branch
+  - "3.9"
 #  - "nightly"  # nightly build
 
 # command to install dependencies

--- a/src/scimschema/_model/attribute.py
+++ b/src/scimschema/_model/attribute.py
@@ -2,6 +2,7 @@ import collections
 import re
 from copy import deepcopy
 from datetime import datetime
+
 from . import scim_exceptions
 
 
@@ -10,7 +11,12 @@ class Attribute:
     _accepted_uniqueness_value = {"none", "server", "global"}
 
     def __init__(
-        self, d, locator_path, is_parent_multi_valued=False, is_parent_complex=False
+        self,
+        d,
+        locator_path,
+        is_parent_multi_valued=False,
+        is_parent_complex=False,
+        attribute_type=None,
     ):
         # default values see - https://tools.ietf.org/html/rfc7643#section-2.2
         # Characteristics # https://tools.ietf.org/html/rfc7643#section-7
@@ -24,7 +30,7 @@ class Attribute:
 
         self.id = d.pop("id", None)
         # self.name = d.pop("name", self.name)
-        self.type = d.pop("type", "string")
+        self.type = attribute_type or d.pop("type")
         self.description = d.pop("description", None)
         self.required = d.pop("required", False)
         self.canonicalValues = d.pop("canonicalValues", None)
@@ -464,6 +470,7 @@ class MultiValuedAttribute(Attribute):
             locator_path=locator_path,
             is_parent_multi_valued=is_parent_multi_valued,
             is_parent_complex=is_parent_complex,
+            attribute_type=self.type,
         )
 
         self.name = self.element_attribute.name
@@ -599,9 +606,8 @@ class AttributeFactory:
                 is_parent_multi_valued=is_parent_multi_valued,
                 is_parent_complex=is_parent_complex,
             )
-        attribute_type = (
-            d.get("type", "string") if attribute_type is None else attribute_type
-        )
+
+        attribute_type = attribute_type or d.get("type")
 
         if attribute_type not in attribute_factory.keys():
             raise AssertionError(

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ with open("./README.rst", "r") as fh:
 
 setup(
     name="scimschema",
-    version="0.1.69",
+    version="0.1.70",
     author="Gordon So",
     author_email="gordonkwso@gmail.com",
     description="A validator for System for Cross-domain Identity Management (SCIM) responses given predefine schemas",

--- a/tests/test_scim_response.py
+++ b/tests/test_scim_response.py
@@ -1,9 +1,14 @@
-import pytest
 import json
 import re
+
+import pytest
+
 from scimschema import core_schemas
+from scimschema._model.attribute import MultiValuedAttribute
 from scimschema._model.schema_response import ScimResponse
+
 from . import extension
+
 # ------------------------------The Following are method tests ------------------------------ #
 
 
@@ -13,28 +18,47 @@ def _dict_to_json(d):
 
 def test_validating_example_user():
     from . import examples
-    ScimResponse(data=examples.user, core_schema_definitions=core_schemas.schema, extension_schema_definitions=extension.schema).validate()
+
+    ScimResponse(
+        data=examples.user,
+        core_schema_definitions=core_schemas.schema,
+        extension_schema_definitions=extension.schema,
+    ).validate()
 
 
 def test_validating_example_group():
     from . import examples
-    ScimResponse(data=examples.group, core_schema_definitions=core_schemas.schema, extension_schema_definitions=extension.schema).validate()
+
+    ScimResponse(
+        data=examples.group,
+        core_schema_definitions=core_schemas.schema,
+        extension_schema_definitions=extension.schema,
+    ).validate()
 
 
 def test_validating_example_custom_user():
     from . import examples
-    ScimResponse(data=examples.customUser, core_schema_definitions=core_schemas.schema, extension_schema_definitions=extension.schema).validate()
+
+    ScimResponse(
+        data=examples.customUser,
+        core_schema_definitions=core_schemas.schema,
+        extension_schema_definitions=extension.schema,
+    ).validate()
 
 
 def test_validating_invalid_example_user():
     user_example_without_username_property = {
         "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-        "id": "2819c223-7f76-453a-919d-413861904646"
+        "id": "2819c223-7f76-453a-919d-413861904646",
     }
     assert_error = None
 
     try:
-        ScimResponse(data=user_example_without_username_property, core_schema_definitions=core_schemas.schema, extension_schema_definitions=extension.schema).validate()
+        ScimResponse(
+            data=user_example_without_username_property,
+            core_schema_definitions=core_schemas.schema,
+            extension_schema_definitions=extension.schema,
+        ).validate()
     except AssertionError as ae:
         assert_error = ae
     assert assert_error is not None
@@ -46,15 +70,20 @@ def test_validating_invalid_example_user():
 
 def test_validating_valid_example_account():
     account_examples = {
-        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group", "urn:huddle:params:scim:schemas:extension:2.0:Account"],
+        "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:Group",
+            "urn:huddle:params:scim:schemas:extension:2.0:Account",
+        ],
         "id": "2819c223-7f76-453a-919d-413861904646",
-        "urn:huddle:params:scim:schemas:extension:2.0:Account": {
-            "package": {}
-        }
+        "urn:huddle:params:scim:schemas:extension:2.0:Account": {"package": {}},
     }
     assert_error = None
     try:
-        ScimResponse(data=account_examples, core_schema_definitions=core_schemas.schema, extension_schema_definitions=extension.schema).validate()
+        ScimResponse(
+            data=account_examples,
+            core_schema_definitions=core_schemas.schema,
+            extension_schema_definitions=extension.schema,
+        ).validate()
     except AssertionError as ae:
         assert_error = ae
     assert assert_error is not None
@@ -69,13 +98,22 @@ def test_get_invalid_meta_schema():
 
     # given a response with a validate schemas attribute - both user and group (for the sack of testing)
     example_with_schemas = _dict_to_json(
-        {"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User", "urn:ietf:params:scim:schemas:core:2.0:Group"]}
+        {
+            "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User",
+                "urn:ietf:params:scim:schemas:core:2.0:Group",
+            ]
+        }
     )
 
     # when get schemas is called
     assert_exception = None
     try:
-        ScimResponse(data=example_with_schemas, core_schema_definitions=core_schemas.schema, extension_schema_definitions=extension.schema)
+        ScimResponse(
+            data=example_with_schemas,
+            core_schema_definitions=core_schemas.schema,
+            extension_schema_definitions=extension.schema,
+        )
     except AssertionError as ae:
         assert_exception = ae
 
@@ -88,18 +126,25 @@ def test_get_meta_schema():
         {"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"]}
     )
     # when get schemas is called
-    scim_response = ScimResponse(data=example_with_schemas, core_schema_definitions=core_schemas.schema, extension_schema_definitions=extension.schema)
+    scim_response = ScimResponse(
+        data=example_with_schemas,
+        core_schema_definitions=core_schemas.schema,
+        extension_schema_definitions=extension.schema,
+    )
     # then it should return the matching modules
-    expected_schemas = {core_schemas.schema["urn:ietf:params:scim:schemas:core:2.0:User"]}
-    assert set(scim_response._core_meta_schemas) == expected_schemas, \
-        "Get schema expected {} but got {}".format([schema["id"] for schema in expected_schemas], [schema["id"] for schema in scim_response])
+    expected_schemas = {
+        core_schemas.schema["urn:ietf:params:scim:schemas:core:2.0:User"]
+    }
+    assert (
+        set(scim_response._core_meta_schemas) == expected_schemas
+    ), "Get schema expected {} but got {}".format(
+        [schema["id"] for schema in expected_schemas],
+        [schema["id"] for schema in scim_response],
+    )
 
 
 @pytest.mark.parametrize(
-    "schema_without_definition", [
-        _dict_to_json({"schemas": []}),
-        _dict_to_json({})
-    ]
+    "schema_without_definition", [_dict_to_json({"schemas": []}), _dict_to_json({})]
 )
 def test_get_meta_schema_without_definitions(schema_without_definition):
     # given a response without a validate schemas attribute is supplied from the row test
@@ -107,12 +152,40 @@ def test_get_meta_schema_without_definitions(schema_without_definition):
     # when get schemas is called
     exception = None
     try:
-        ScimResponse(schema_without_definition, core_schema_definitions=core_schemas.schema, extension_schema_definitions=extension.schema)
+        ScimResponse(
+            schema_without_definition,
+            core_schema_definitions=core_schemas.schema,
+            extension_schema_definitions=extension.schema,
+        )
     except AssertionError as ke:
         exception = ke
 
     # then exceptions should be raised
     assert isinstance(exception, AssertionError)
-    assert 'Response has no specified schema' in str(exception)
+    assert "Response has no specified schema" in str(exception)
 
 
+def test_core_schema_definitions():
+    def get_schema_attribute():
+        for key, val in core_schemas.schema.items():
+            for attr in val.attributes:
+                if attr.type == "complex":
+                    if not attr.multiValued:
+                        for s in attr.subAttributes:
+                            yield s.name
+                    elif (
+                        attr.multiValued
+                        and hasattr(attr, "element_attribute")
+                        and attr.element_attribute.type == "complex"
+                    ):
+                        for s in attr.element_attribute.subAttributes:
+                            yield s.name
+                    else:
+                        raise NotImplementedError("unknown attribute")
+                yield attr.name
+
+    attribute_generator = get_schema_attribute()
+    attribute_list = list(attribute_generator)
+    assert "emails" in attribute_list
+    assert "addresses" in attribute_list
+    print(attribute_list)


### PR DESCRIPTION
Until v0.1.69, there is an implementation bug with multiValue attribute, the parent attribute would always be type: 'string'.
This had no impact to schema validation due to that multiValue attribute is structures in two layers, the parent was incorrectly parsed as type 'string' but was only used to convey the 'multi-value' characteristic, whereas the subAttribute is parsed with the correct type.

The bug was discovered by https://github.com/GordonSo/scimschema/issues/25 where implementation was relied upon to expose the element's properties, and it was discovered some 'complex multi-value' types were missing. 

New test now contains example code to discover schema's attributes:

https://github.com/GordonSo/scimschema/compare/ISSUE25---fixed-multiValue-complex-type?expand=1#diff-95a8d14c4b0977222c1e9b2561057c15b1cf74ce3c4c5b1ddc362efa533c6979R168-R191
